### PR TITLE
fix: index registry flakey fuzz test

### DIFF
--- a/test/unit/IndexRegistryUnit.t.sol
+++ b/test/unit/IndexRegistryUnit.t.sol
@@ -415,6 +415,7 @@ contract EOIndexRegistryUnitTests_registerOperator is EOIndexRegistryUnitTests {
     function testFuzz_Revert_WhenNonEORegistryCoordinator(address nonEORegistryCoordinator) public {
         cheats.assume(nonEORegistryCoordinator != address(registryCoordinator));
         cheats.assume(nonEORegistryCoordinator != proxyAdminOwner);
+        cheats.assume(nonEORegistryCoordinator != address(proxyAdmin));
         bytes memory quorumNumbers = new bytes(defaultQuorumNumber);
 
         cheats.prank(nonEORegistryCoordinator);


### PR DESCRIPTION
in IndexRegistry unit test, testFuzz_Revert_WhenNonEORegistryCoordinator was failing sometimes due to not filtering proxyAdmin address.